### PR TITLE
Use Flask SQLAlchemy Extension to manage DB connections

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,44 @@
+Zope Public License (ZPL) Version 2.1
+
+A copyright notice accompanies this license document that identifies the
+copyright holders.
+
+This license has been certified as open source. It has also been designated as
+GPL compatible by the Free Software Foundation (FSF).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions in source code must retain the accompanying copyright
+notice, this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the accompanying copyright
+notice, this list of conditions, and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Names of the copyright holders must not be used to endorse or promote
+products derived from this software without prior written permission from the
+copyright holders.
+
+4. The right to distribute this software or to use it for any purpose does not
+give you the right to use Servicemarks (sm) or Trademarks (tm) of the
+copyright
+holders. Use of them is covered by separate agreement with the copyright
+holders.
+
+5. If any files are modified, you must cause the modified files to carry
+prominent notices stating that you changed the files and the date of any
+change.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY EXPRESSED
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+addopts = "--tb=native --cov=src --cov-report=html src"
+
+[tool.mypy]
+ignore_errors = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --tb=native --cov=src --cov-report=html src

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-"""Authenticate an nginx request against an SQL database
-"""
+"""Authenticate an nginx request against an SQL database."""
+# -*- coding: utf-8 -*-
+
 from setuptools import setup, find_packages
 import glob
 
@@ -12,11 +13,15 @@ setup(
         'flask',
         'setuptools',
         'sqlalchemy>=2.0.0',
+        'Flask-SQLAlchemy',
     ],
 
-    extras_require={'test': [
-        'pytest',
-    ]},
+    extras_require={
+        'test': [
+            'passlib',
+            'pytest-cov',
+        ],
+    },
 
     entry_points={
         'console_scripts': [

--- a/src/ws/nginxdbauth/tests/test_web.py
+++ b/src/ws/nginxdbauth/tests/test_web.py
@@ -1,28 +1,40 @@
 # coding: utf8
-from sqlalchemy import text
 import base64
 import os
+
 import passlib.context
 import pytest
-import sqlalchemy
 import ws.nginxdbauth.web
 
 
 @pytest.fixture
 def database(tmpdir):
-    db = sqlalchemy.create_engine('sqlite:////%s' % tmpdir.join('auth.db'))
-    conn = db.connect()
-    conn.execute(text(
-        'CREATE TABLE users ('
-        'id integer, username varchar(40), password varchar(40), '
-        'role varchar(40))'))
-    conn.execute(
-        text('INSERT INTO users VALUES (1, "normal", "asdf", "normal")'))
-    conn.execute(
-        text('INSERT INTO users VALUES (2, "super", "qwer", "super")'))
-    conn.commit()
-    conn.url = db.url
-    return conn
+    db = ws.nginxdbauth.web.db
+    ws.nginxdbauth.web.app.config['SQLALCHEMY_DATABASE_URI'] = (
+        'sqlite:////%s' % tmpdir.join('auth.db')
+    )
+    try:
+        db.init_app(ws.nginxdbauth.web.app)
+    except RuntimeError:
+        pass
+
+    with ws.nginxdbauth.web.app.app_context():
+        db.session.execute(
+            db.text(
+                'CREATE TABLE users ('
+                'id integer, username varchar(40), password varchar(40), '
+                'role varchar(40))'
+            )
+        )
+        db.session.execute(
+            db.text('INSERT INTO users VALUES (1, "normal", "asdf", "normal")')
+        )
+        db.session.execute(
+            db.text('INSERT INTO users VALUES (2, "super", "qwer", "super")')
+        )
+        db.session.commit()
+        yield db
+        db.session.execute(db.text('DROP TABLE users'))
 
 
 @pytest.fixture
@@ -30,29 +42,42 @@ def config(monkeypatch):
     os.environ['NGINXDBAUTH_CONFIG'] = '/dev/null'
 
     def inner(config):
-        monkeypatch.setattr('ws.nginxdbauth.web.ConfigParser.get',
-                            lambda self, s, x: config.get(x))
-        monkeypatch.setattr('ws.nginxdbauth.web.ConfigParser.has_option',
-                            lambda self, s, x: x in config)
+        monkeypatch.setattr(
+            'ws.nginxdbauth.web.ConfigParser.get',
+            lambda self, s, x: config.get(x)
+        )
+        monkeypatch.setattr(
+            'ws.nginxdbauth.web.ConfigParser.has_option',
+            lambda self, s, x: x in config
+        )
     return inner
 
 
 def basic_auth(username, password):
-    return {'Authorization': 'Basic '.encode('ascii') + base64.b64encode(
-        u':'.join([username, password]).encode('latin1'))}
+    return {
+        'Authorization': 'Basic '.encode('ascii') + base64.b64encode(
+            u':'.join([username, password]).encode('latin1')
+        )
+    }
 
 
 def test_correct_password_returns_200(config, database):
-    config({'dsn': database.url, 'query': 'SELECT id FROM users WHERE '
-            'username = :username AND password = :password'})
+    config({
+        'dsn': ws.nginxdbauth.web.app.config['SQLALCHEMY_DATABASE_URI'],
+        'query': 'SELECT id FROM users WHERE '
+                 'username = :username AND password = :password',
+    })
     b = ws.nginxdbauth.web.app.test_client()
     r = b.get('/', headers=basic_auth('normal', 'asdf'))
     assert r.status_code == 200, r.data.decode('ascii')
 
 
 def test_wrong_password_returns_403(config, database):
-    config({'dsn': database.url, 'query': 'SELECT id FROM users WHERE '
-            'username = :username AND password = :password'})
+    config({
+        'dsn': ws.nginxdbauth.web.app.config['SQLALCHEMY_DATABASE_URI'],
+        'query': 'SELECT id FROM users WHERE '
+                 'username = :username AND password = :password'
+    })
     b = ws.nginxdbauth.web.app.test_client()
     r = b.get('/', headers=basic_auth('normal', 'invalid'))
     assert r.status_code == 403, r.data.decode('ascii')
@@ -60,8 +85,11 @@ def test_wrong_password_returns_403(config, database):
 
 def test_headers_are_available_as_query_parameters(config, database):
     config({
-        'dsn': database.url, 'query': 'SELECT id FROM users WHERE '
-        'username = :username AND password = :password AND role = :x_role'})
+        'dsn': ws.nginxdbauth.web.app.config['SQLALCHEMY_DATABASE_URI'],
+        'query': 'SELECT id FROM users WHERE '
+                 'username = :username AND password = :password '
+                 'AND role = :x_role'
+    })
     b = ws.nginxdbauth.web.app.test_client()
     headers = basic_auth('super', 'qwer')
     headers['X-Role'] = 'super'
@@ -75,11 +103,16 @@ def test_headers_are_available_as_query_parameters(config, database):
 
 
 def test_handles_non_ascii_entries(config, database):
-    database.execute(text(
-        u'INSERT INTO users VALUES (3, "ümläut", "asdf", "")'))
-    database.commit()
-    config({'dsn': database.url, 'query': 'SELECT id FROM users WHERE '
-            'username = :username AND password = :password'})
+    with ws.nginxdbauth.web.app.app_context():
+        database.session.execute(database.text(
+            u'INSERT INTO users VALUES (3, "ümläut", "asdf", "")'
+        ))
+        database.session.commit()
+    config({
+        'dsn': ws.nginxdbauth.web.app.config['SQLALCHEMY_DATABASE_URI'],
+        'query': 'SELECT id FROM users WHERE '
+                 'username = :username AND password = :password'
+    })
     b = ws.nginxdbauth.web.app.test_client()
     r = b.get('/', headers=basic_auth(u'ümläut', 'asdf'))
     assert r.status_code == 200, r.data.decode('ascii')
@@ -87,12 +120,17 @@ def test_handles_non_ascii_entries(config, database):
 
 def test_password_hashing_with_passlib(config, database):
     pwd_context = passlib.context.CryptContext(schemes=['sha256_crypt'])
-    database.execute(text('INSERT INTO users VALUES (3, "foo", :pw, "")'),
-                     dict(pw=pwd_context.hash('secret')))
-    database.commit()
-    config({'dsn': database.url,
-            'query': 'SELECT password FROM users WHERE username = :username',
-            'password_hash': 'sha256_crypt'})
+    with ws.nginxdbauth.web.app.app_context():
+        database.session.execute(
+            database.text('INSERT INTO users VALUES (3, "foo", :pw, "")'),
+            dict(pw=pwd_context.hash('secret')),
+        )
+        database.session.commit()
+    config({
+        'dsn': ws.nginxdbauth.web.app.config['SQLALCHEMY_DATABASE_URI'],
+        'query': 'SELECT password FROM users WHERE username = :username',
+        'password_hash': 'sha256_crypt',
+    })
     b = ws.nginxdbauth.web.app.test_client()
     r = b.get('/', headers=basic_auth('foo', 'secret'))
     assert r.status_code == 200, r.data.decode('ascii')


### PR DESCRIPTION
# Problem

- The server is currently spawning new Database connections per request, and holding them open till the program ends.
- Configuration is also reparsed on each request instead of reusing configuration on-startup.

# Solution

- Use the [Flask SQLAlchemy Extension](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/) to automatically manage the database connection according to best-practices.
- Setup the connection prior to serving the webapp
- Update unit-tests to use new syntax
- Move pytest.ini configs into newer pyproject.toml format
- [Add license txt](https://github.com/wosc/nginx-db-auth/issues/1)
- Took the liberty to try and make some long lines continuations bit more readable.

**BEFORE (using 1.0.4):**
![Screenshot from 2023-03-16 12-41-19](https://user-images.githubusercontent.com/1868705/225607582-69f029ed-95da-47a0-b4fb-bc03a1092250.png)

**AFTER (using this PR):**
![Screenshot from 2023-03-16 12-42-16](https://user-images.githubusercontent.com/1868705/225607569-dd8bf5a0-f1e8-4535-88d0-4711adadfe4e.png)
